### PR TITLE
Move to pull source code and documentation from github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ NB. This is very brittle, the script does absolutely no error checking.
 
 ## Prerequisites
 Before you attempt to run this script **from a root shell on the target host** you should:
+1. have a default Debian install on a machine you control
 1. ensure you can ssh as root with no password to your host (i.e. with a ssh key)
 1. ensure you can set up LetsEncrypt for your domain, and reach a state where the certificate renewal actually renews your certificates by simply running `cd /var/lib/dehydrated; dehydrated -c`.
 1. have asked your hosting provider to set up reverse DNS (**rDNS**) to resolve to your *example.com* (replace this with your own domain), and ensured that they did it by running `host ip.addr.of.host`.

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -126,7 +126,7 @@ function mainInstall {
 	echo '##########################################################################'
 	echo '### download and patch spamgourmet code'
 	echo '##########################################################################'
-	svn co https://svn.code.sf.net/p/spamgourmet/code/ code
+	git clone https://github.com/spamgourmet/spamgourmet.git code
 
 	cd code
 	OLDIFS=$IFS;IFS=$'\n'
@@ -233,7 +233,7 @@ function mainInstall {
 	cat <<-EOF >/etc/systemd/system/captchasrv.service
 	[Unit]
 	Description=spamgourmet captcha service
-	Documentation=https://sourceforge.net/p/spamgourmet/code/HEAD/tree/captchasrv/
+	Documentation=https://github.com/spamgourmet/spamgourmet/tree/master/captchasrv
 
 	[Service]
 	ExecStart=/usr/local/lib/spamgourmet/captchasrv/captchasrv.pl


### PR DESCRIPTION
The new repo on GitHub is at least somewhat active and has changes and fixes that have actully been delivered to spamgourmet.com so it is now more update than sourceforge.  It would be nice if spamgourmet-clone was updated to use that.  

I've already forked spamgourmet-clone into spamgourmet/spamgourmet-clone

a) if you'd like the spamgourmet/spamgourmet-clone repo to be the master repo I'd be very very happy to help

b) I'm going to invite you into the spamgourmet organisation - would be really happy if you wanted to and super happy if you contributed in some way in future.  Just accept or don't on the invitation.

- mikedlr